### PR TITLE
Create Github Actions for Basic Build and Deploy

### DIFF
--- a/.github/workflows/AzMan_CICD.yml
+++ b/.github/workflows/AzMan_CICD.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
     - name: 'Checkout GitHub Action'
       uses: actions/checkout@master

--- a/.github/workflows/AzMan_CICD.yml
+++ b/.github/workflows/AzMan_CICD.yml
@@ -1,0 +1,49 @@
+name: Deploy AzMan project to Azure Function App
+
+on:
+  [push]
+
+# CONFIGURATION
+# For help, go to https://github.com/Azure/Actions
+#
+# 1. Set up the following secrets in your repository:
+#   AZURE_RBAC_CREDENTIALS
+#
+# 2. Change these variables for your configuration:
+env:
+  AZURE_FUNCTIONAPP_NAME: ' '  # set this to your application's name
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'    # set this to the path to your web app project, defaults to the repository root
+  DOTNET_VERSION: '3.1'              # set this to the dotnet version to use
+
+jobs:
+  build-and-deploy:
+    runs-on: windows-latest
+    steps:
+    - name: 'Checkout GitHub Action'
+      uses: actions/checkout@master
+
+    - name: 'Login via Azure CLI'
+      uses: azure/login@v1
+      with:
+        creds: ${{ secrets.AZURE_RBAC_CREDENTIALS }}
+
+    - name: Setup DotNet ${{ env.DOTNET_VERSION }} Environment
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: ${{ env.DOTNET_VERSION }}
+
+    - name: 'Resolve Project Dependencies Using Dotnet'
+      shell: pwsh
+      run: |
+        pushd './${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}'
+        dotnet build --configuration Release --output ./output
+        popd
+
+    - name: 'Run Azure Functions Action'
+      uses: Azure/functions-action@v1
+      id: fa
+      with:
+        app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+        package: '${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}/output'
+
+# For more samples to get started with GitHub Action workflows to deploy to Azure, refer to https://github.com/Azure/actions-workflow-samples


### PR DESCRIPTION
Create AzMan_CICD.yml in .github/workflows/ 

YAML File that contains the GH Action instructions to build AzMan and Push to Function in Azure using RBAC AAD Service Principal

SP Created using the following CLI command, resulting JSON output should be put in a secret for the repo called AZURE_RBAC_CREDENTIALS

`az ad sp create-for-rbac --name "myApp" --role contributor --scopes /subscriptions/{subscription-id}/resourceGroups/{resource-group}/providers/Microsoft.Web/sites/{app-name} --sdk-auth`

ENV Variable `AZURE_FUNCTIONAPP_NAME` needs to be updated with the name of the function app deployed in Azure that the SP has permissions scoped to.

Workflow is triggered on any push to the repo, can be updated / filtered - https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows 